### PR TITLE
Ensure view is fully loaded before pagination

### DIFF
--- a/ReportPaginator/Paginator.cs
+++ b/ReportPaginator/Paginator.cs
@@ -34,6 +34,7 @@ namespace Sherman.WpfReporting.Lib
             while (processing)
             {
                 var newPage = pageFactory();
+                await Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Render, new Action(() => newPage.UpdateLayout()));
                 var pageLogicalChildren = FindLogicalChildren(newPage).ToList();
 
                 pageNumber++;


### PR DESCRIPTION
I found that if my report view is heavily databound, with multiple embedded views, pagination fails as the view hasn't loaded 
 (itemscontrols are still empty). This fix forces the dispatcher to layout the view before attempting pagination.